### PR TITLE
Update Quickstarts wrt current config manager API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -624,10 +624,10 @@ The diagram below illustrates the complete dependency flow between major compone
 Ember's configuration system provides a standardized way to configure all aspects of the framework:
 
 ```python
-from ember.core.configs import ConfigManager, create_default_config_manager
+from ember.core.configs import ConfigManager, create_config_manager
 
 # Create configuration manager with standard discovery
-config_manager = create_default_config_manager()
+config_manager = create_config_manager()
 
 # Access typed, validated configuration
 model_registry_config = config_manager.get_config("model_registry")

--- a/docs/quickstart/ .md
+++ b/docs/quickstart/ .md
@@ -16,10 +16,10 @@ The configuration system is built around these key components:
 The simplest way to use the configuration system is with the config manager:
 
 ```python
-from ember.core.configs.config_manager import create_default_config_manager
+from ember.core.config.manager import create_config_manager
 
 # Create a configuration manager
-config_manager = create_default_config_manager()
+config_manager = create_config_manager()
 
 # Access configuration
 config = config_manager.get_config()
@@ -293,8 +293,8 @@ registry = initialize_ember(auto_discover=True)
 
 # New way - preferred approach
 from ember.core.registry.model.initialization import initialize_registry
-from ember.core.configs.config_manager import create_default_config_manager
-config_manager = create_default_config_manager()
+from ember.core.config.manager import create_config_manager
+config_manager = create_config_manager()
 registry = initialize_registry(config_manager=config_manager)
 ```
 
@@ -325,7 +325,7 @@ For complete configuration examples, see:
 3. **Validate Configuration Early**:
    ```python
    # Create and validate on startup
-   config_manager = create_default_config_manager()
+   config_manager = create_config_manager()
    config = config_manager.get_config()
    ```
 
@@ -339,8 +339,8 @@ For complete configuration examples, see:
 5. **Create Environment-Specific Config Providers**:
    ```python
    # Development
-   config_manager = create_default_config_manager("config.dev.yaml")
+   config_manager = create_config_manager("config.dev.yaml")
    
    # Production
-   config_manager = create_default_config_manager("config.prod.yaml")
+   config_manager = create_config_manager("config.prod.yaml")
    ```

--- a/docs/quickstart/model_registry.md
+++ b/docs/quickstart/model_registry.md
@@ -52,11 +52,11 @@ print(response.data)
 
 ```python
 from ember.core.registry.model.initialization import initialize_registry
-from ember.core.configs.config_manager import create_default_config_manager
+from ember.core.config.manager import create_config_manager
 from ember.core.registry.model.base.services.model_service import ModelService
 
 # Initialize the configuration and registry
-config_manager = create_default_config_manager()
+config_manager = create_config_manager()
 registry = initialize_registry(config_manager=config_manager)
 
 # Create a service instance
@@ -85,12 +85,12 @@ print(response.data)
 
 ```python
 from ember.core.registry.model.initialization import initialize_registry
-from ember.core.configs.config_manager import create_default_config_manager
+from ember.core.config.manager import create_config_manager
 from ember.core.registry.model.base.services.model_service import ModelService
 from ember.core.registry.model.base.services.usage_service import UsageService
 
 # Initialize configuration and registry with usage tracking
-config_manager = create_default_config_manager()
+config_manager = create_config_manager()
 registry = initialize_registry(config_manager=config_manager)
 usage_service = UsageService()
 service = ModelService(registry=registry, usage_service=usage_service)
@@ -149,11 +149,11 @@ registry.register_model(custom_model)
 
 ```python
 from ember.core.registry.model.initialization import initialize_registry  
-from ember.core.configs.config_manager import create_default_config_manager
+from ember.core.config.manager import create_config_manager
 from ember.core.registry.model.config.model_enum import ModelEnum
 
 # Initialize the registry with configuration
-config_manager = create_default_config_manager()
+config_manager = create_config_manager()
 service = initialize_registry(config_manager=config_manager)
 
 # Use enum for type-safety


### PR DESCRIPTION
OOTB error triggered by following the current quickstart docs (outdated API):
```
>>> from ember.core.configs.config_manager import create_default_config_manager
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'ember.core.configs.config_manager'
```

Behavior following modified quickstart documentation (this PR):
```
$python
>>> from ember.core.config.manager import create_config_manager
2025-03-17 12:10:46,708 [DEBUG] ConfigManager: Loading configuration...
2025-03-17 12:10:46,708 [DEBUG] ConfigManager: Configuration loaded successfully
2025-03-17 12:10:46,708 [INFO] ember.core.registry.model.initialization: Running model discovery...
2025-03-17 12:10:47,791 [INFO] ember.core.registry.model.base.registry.discovery: OPENAI_API_KEY not found, skipping OpenAIDiscovery
2025-03-17 12:10:47,791 [INFO] ember.core.registry.model.base.registry.discovery: ANTHROPIC_API_KEY not found, skipping AnthropicDiscovery
2025-03-17 12:10:47,791 [INFO] ember.core.registry.model.base.registry.discovery: GOOGLE_API_KEY not found, skipping DeepmindDiscovery
2025-03-17 12:10:47,791 [WARNING] ember.core.registry.model.base.registry.discovery: No API keys found for any providers. Set one of OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY environment variables to enable discovery.
2025-03-17 12:10:47,792 [INFO] ember.core.registry.model.initialization: Initiating model discovery via ModelDiscoveryService
2025-03-17 12:10:47,792 [INFO] ember.core.registry.model.base.registry.discovery: Discovered models: []
2025-03-17 12:10:47,792 [INFO] ember.core.registry.model.initialization: No models discovered from provider APIs
2025-03-17 12:10:47,792 [INFO] ember.core.registry.model.initialization: No new models discovered
>>> manager = create_config_manager()
2025-03-17 12:10:55,893 [DEBUG] ConfigManager: Loading configuration...
2025-03-17 12:10:55,893 [DEBUG] ConfigManager: Configuration loaded successfully
```