### PR TITLE
Added skip_dataset_discovery argument to initialize_registry in registry.py

### DIFF
--- a/src/ember/core/utils/data/registry.py
+++ b/src/ember/core/utils/data/registry.py
@@ -264,8 +264,11 @@ def register(
 
 
 # Initialize the registry with core datasets
-def initialize_registry() -> None:
-    """Initialize the dataset registry with core datasets."""
+def initialize_registry(skip_dataset_discovery: bool = False) -> None:
+    """Initialize the dataset registry with core datasets.
+    Args:
+        skip_dataset_discovery: If True, skips automatic discovery of datasets.
+    """
     # Register core datasets from legacy registry
     from ember.core.utils.data.datasets_registry import (
         commonsense_qa,
@@ -317,4 +320,5 @@ def initialize_registry() -> None:
     )
 
     # Discover datasets in the ember.data.datasets package
-    UNIFIED_REGISTRY.discover_datasets()
+    if not skip_dataset_discovery:
+        UNIFIED_REGISTRY.discover_datasets()


### PR DESCRIPTION
Added skip_dataset_discovery argument so that dataset_discovery is togglable, default is False. This might be useful during testing, as I when I was using ember the dataset discovery took up time and printed excessive log statements which I didn't need while testing.

This feature gives callers the ability to initialize the registry with only core datasets, skipping the discovery process when it's not needed.